### PR TITLE
Replace token verification with OTP-based auth flow

### DIFF
--- a/server/routes/AuthRoute.js
+++ b/server/routes/AuthRoute.js
@@ -20,5 +20,4 @@ router.post("/change-password-first", requireAuth, changePasswordFirst);
 router.post("/verify-otp", verifyOtp);
 router.post("/resend-otp", resendOtp);
 
-
 export default router;

--- a/server/routes/AuthRoute.js
+++ b/server/routes/AuthRoute.js
@@ -7,9 +7,6 @@ import {
   changePasswordFirst,
   verifyOtp,
   resendOtp,
-  sendVerification,
-  setPassword,
-  resendVerification,
 } from "../controllers/AuthController.js";
 import { requireAuth } from "../middleware/auth.js";
 
@@ -23,9 +20,5 @@ router.post("/change-password-first", requireAuth, changePasswordFirst);
 router.post("/verify-otp", verifyOtp);
 router.post("/resend-otp", resendOtp);
 
-// Verification endpoints
-router.post("/send-verification", sendVerification);
-router.post("/set-password", setPassword);
-router.post("/resend-verification", resendVerification);
 
 export default router;


### PR DESCRIPTION
## Purpose
The user wanted to replace the current token-based email verification system with an OTP (One-Time Password) based authentication flow. This change simplifies the verification process by sending a 6-digit OTP via email instead of verification links with tokens.

## Code changes
- **Removed token-based verification**: Eliminated `generateToken`, `hashToken`, and related verification endpoints (`verifyHandler`, `sendVerification`, `setPassword`, `resendVerification`)
- **Implemented OTP system**: Added OTP generation, hashing, and verification with `hashOTP()` function using PBKDF2
- **Updated signup flow**: Changed from sending verification links to sending 6-digit OTPs with 10-minute expiration
- **Added OTP endpoints**: Implemented `verifyOtp` and `resendOtp` handlers with rate limiting and attempt tracking
- **Enhanced security**: Added OTP attempt limits (6 attempts) with 24-hour lockout period
- **Improved code formatting**: Applied consistent formatting and multi-line structure for better readability
- **Updated logout**: Changed from `jwt.decode` to `jwt.verify` for proper token validation
- **Cleaned up routes**: Removed unused verification route handlers from AuthRoute.js

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 6`

🔗 [Edit in Builder.io](https://builder.io/app/projects/4c5bd40bc73a4370a7718834a2ae10ca/spark-garden)

👀 [Preview Link](https://4c5bd40bc73a4370a7718834a2ae10ca-spark-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>4c5bd40bc73a4370a7718834a2ae10ca</projectId>-->
<!--<branchName>spark-garden</branchName>-->